### PR TITLE
add functioncode 0x10

### DIFF
--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -198,6 +198,31 @@ size_t ModbusRequest04::responseLength() {
   return 5 + _byteCount;
 }
 
+ModbusRequest16::ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data) :
+  ModbusRequest(9 + (numberRegisters * 2)) {
+  _slaveAddress = slaveAddress;
+  _functionCode = esp32Modbus::WRITE_MULT_REGISTERS;
+  _address = address;
+  _byteCount = numberRegisters * 2;  // register is 2 bytes wide
+  add(_slaveAddress);
+  add(_functionCode);
+  add(high(_address));
+  add(low(_address));
+  add(high(numberRegisters));
+  add(low(numberRegisters));
+  add(_byteCount);
+  for (int i = 0; i < _byteCount; i++) {
+      add(data[i]);
+    }
+  uint16_t CRC = CRC16(_buffer, 7 + _byteCount);
+  add(low(CRC));
+  add(high(CRC));
+}
+
+size_t ModbusRequest16::responseLength() {
+  return 8;
+}
+
 ModbusResponse::ModbusResponse(uint8_t length, ModbusRequest* request) :
   ModbusMessage(length),
   _request(request),

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -81,6 +81,13 @@ class ModbusRequest04 : public ModbusRequest {
   size_t responseLength();
 };
 
+// write multiple holding registers
+class ModbusRequest16 : public ModbusRequest {
+ public:
+  explicit ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data);
+  size_t responseLength();
+};
+
 class ModbusResponse : public ModbusMessage {
  public:
   explicit ModbusResponse(uint8_t length, ModbusRequest* request);

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -68,6 +68,11 @@ bool esp32ModbusRTU::readInputRegisters(uint8_t slaveAddress, uint16_t address, 
   return _addToQueue(request);
 }
 
+bool esp32ModbusRTU::writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data) {
+  ModbusRequest* request = new ModbusRequest16(slaveAddress, address, numberRegisters, data);
+  return _addToQueue(request);
+}
+
 void esp32ModbusRTU::onData(esp32Modbus::MBRTUOnData handler) {
   _onData = handler;
 }

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -55,6 +55,7 @@ class esp32ModbusRTU {
   bool readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils);
   bool readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
   bool readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
+  bool writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data);
   void onData(esp32Modbus::MBRTUOnData handler);
   void onError(esp32Modbus::MBRTUOnError handler);
 


### PR DESCRIPTION
This adds functioncode 0x10 write multiple registers functionality.
Tested only on SDM120 to change the settings of the meter, writing 2 parameters at once as described in the manual. Unfortunatly I have no slave devices available to test writes with different data length.

EDIT writing two parameters on SDM as tested is writing 4 bytes.