### PR TITLE
add register address to onData signature

### DIFF
--- a/examples/SDM630/SDM630.ino
+++ b/examples/SDM630/SDM630.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(115200);  // Serial output
   Serial1.begin(9600, SERIAL_8N1, 17, 4, true);  // Modbus connection
 
-  modbus.onData([](uint8_t serverAddress, esp32Modbus::FunctionCode fc, uint8_t* data, size_t length) {
+  modbus.onData([](uint8_t serverAddress, esp32Modbus::FunctionCode fc, uint16_t address, uint8_t* data, size_t length) {
     Serial.printf("id 0x%02x fc 0x%02x len %u: 0x", serverAddress, fc, length);
     for (size_t i = 0; i < length; ++i) {
       Serial.printf("%02x", data[i]);

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -134,6 +134,10 @@ ModbusRequest::ModbusRequest(uint8_t length) :
   _address(0),
   _byteCount(0) {}
 
+  uint16_t ModbusRequest::getAddress() {
+  return _address;
+}
+  
 ModbusRequest02::ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils) :
   ModbusRequest(8) {
   _slaveAddress = slaveAddress;

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -137,7 +137,7 @@ ModbusRequest::ModbusRequest(uint8_t length) :
   uint16_t ModbusRequest::getAddress() {
   return _address;
 }
-  
+
 ModbusRequest02::ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils) :
   ModbusRequest(8) {
   _slaveAddress = slaveAddress;

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -51,6 +51,7 @@ class ModbusResponse;  // forward declare for use in ModbusRequest
 class ModbusRequest : public ModbusMessage {
  public:
   virtual size_t responseLength() = 0;
+  uint16_t getAddress();
 
  protected:
   explicit ModbusRequest(uint8_t length);

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -99,7 +99,7 @@ void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
     instance->_send(request->getMessage(), request->getSize());
     ModbusResponse* response = instance->_receive(request);
     if (response->isSucces()) {
-      if (instance->_onData) instance->_onData(response->getSlaveAddress(), response->getFunctionCode(), response->getData(), response->getByteCount());
+      if (instance->_onData) instance->_onData(response->getSlaveAddress(), response->getFunctionCode(), request->getAddress(), response->getData(), response->getByteCount());
     } else {
       if (instance->_onError) instance->_onError(response->getError());
     }

--- a/src/esp32ModbusTypeDefs.h
+++ b/src/esp32ModbusTypeDefs.h
@@ -61,7 +61,7 @@ enum Error : uint8_t {
 };
 
 typedef std::function<void(uint16_t, uint8_t, esp32Modbus::FunctionCode, uint8_t*, uint16_t)> MBTCPOnData;
-typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint8_t*, uint16_t)> MBRTUOnData;
+typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint16_t, uint8_t*, uint16_t)> MBRTUOnData;
 typedef std::function<void(uint16_t, esp32Modbus::Error)> MBTCPOnError;
 typedef std::function<void(esp32Modbus::Error)> MBRTUOnError;
 


### PR DESCRIPTION
Hi,

When I read from several registers from a slave device I have no way to distinguish between the responses in onData. I added the register address to its signature to facilitate the further processing of the data in the responses.