### PR TITLE
increase version number for platformio crawler to pick up latest version

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32ModbusRTU",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "keywords": "Arduino, ESP32, Modbus, RTU",
   "description": "async Modbus-RTU client for ESP32",
   "homepage": "https://github.com/bertmelis/esp32ModbusRTU",


### PR DESCRIPTION
I have installed this library via PlatformIO. Unfortunately i got a old version without function code 03, 02 and 10. (error: 'class esp32ModbusRTU' has no member named 'readHoldingRegisters')

According to https://docs.platformio.org/en/latest/librarymanager/config.html#version
PlatformIO Library Registry Crawler updates library only if:
        * the version is changed
        * library.json is modified
So hopefully after this PR the pio crawler picks up the latest changes..
