### PR TITLE
Add the option to pin the "background" task to an ESP32 Core CPU

### DIFF
--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -42,10 +42,10 @@ esp32ModbusRTU::~esp32ModbusRTU() {
   // TODO(bertmelis): kill task and cleanup
 }
 
-void esp32ModbusRTU::begin() {
+void esp32ModbusRTU::begin(int coreID /* = -1 */) {
   pinMode(_rtsPin, OUTPUT);
   digitalWrite(_rtsPin, LOW);
-  xTaskCreate((TaskFunction_t)&_handleConnection, "esp32ModbusRTU", 4096, this, 5, &_task);
+  xTaskCreatePinnedToCore((TaskFunction_t)&_handleConnection, "esp32ModbusRTU", 4096, this, 5, &_task, coreID >= 0 ? coreID : NULL);
   // silent interval is at least 3.5x character time
   _interval = 40000 / _serial->baudRate();  // 4 * 1000 * 10 / baud
   if (_interval == 0) _interval = 1;  // minimum of 1msec interval

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -51,7 +51,7 @@ class esp32ModbusRTU {
  public:
   explicit esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin = -1);
   ~esp32ModbusRTU();
-  void begin();
+  void begin(int coreID = -1);
   bool readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils);
   bool readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
   bool readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);


### PR DESCRIPTION
The _internal created task_ can now be **pinned** to an ESP32 Core CPU. Doing so, also the `onData` and `onError` are pinned to that Core.