### PR TITLE
Auto halfduplex fix

### DIFF
--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,8 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
-    {
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) { // block and wait for queued item
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);
       if (response->isSucces()) {

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,7 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if(pdTRUE==xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
     {
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,7 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) { // block and wait for queued item
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) {  // block and wait for queued item
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);
       if (response->isSucces()) {


### PR DESCRIPTION
Use rtsPin only if really needed for RS485 modules with RE/DI lines (constructor called with a pin number >= 0). For auto half-duplex modules the pin would be wasted.