### PR TITLE
Config timeout

### DIFF
--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -28,15 +28,14 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using namespace esp32ModbusRTUInternals;  // NOLINT
 
-uint32_t esp32ModbusRTU::TimeOutValue = TIMEOUT_MS;
-
 esp32ModbusRTU::esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin) :
   _serial(serial),
   _lastMillis(0),
   _interval(0),
   _rtsPin(rtsPin),
   _task(nullptr),
-  _queue(nullptr) {
+  _queue(nullptr),
+  TimeOutValue(TIMEOUT_MS)  {
     _queue = xQueueCreate(QUEUE_SIZE, sizeof(ModbusRequest*));
 }
 

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,8 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
-    {
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) { // block and wait for queued item
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);
       if (response->isSucces()) {

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -28,6 +28,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using namespace esp32ModbusRTUInternals;  // NOLINT
 
+uint32_t esp32ModbusRTU::TimeOutValue = TIMEOUT_MS;
+
 esp32ModbusRTU::esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin) :
   _serial(serial),
   _lastMillis(0),
@@ -125,6 +127,11 @@ void esp32ModbusRTU::_send(uint8_t* data, uint8_t length) {
   _lastMillis = millis();
 }
 
+// Adjust timeout on MODBUS - some slaves require longer/allow for shorter times
+void esp32ModbusRTU::setTimeOutValue(uint32_t tov) {
+  if (tov) TimeOutValue = tov;
+}
+
 ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   ModbusResponse* response = new ModbusResponse(request->responseLength(), request);
   while (true) {
@@ -135,7 +142,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       _lastMillis = millis();
       break;
     }
-    if (millis() - _lastMillis > TIMEOUT_MS) {
+    if (millis() - _lastMillis > TimeOutValue) {
       break;
     }
     delay(1);  // take care of watchdog

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,7 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if(pdTRUE==xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY))  // block and wait for queued item
     {
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -97,7 +97,7 @@ bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
 void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
   while (1) {
     ModbusRequest* request;
-    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) { // block and wait for queued item
+    if (pdTRUE == xQueueReceive(instance->_queue, &request, portMAX_DELAY)) {  // block and wait for queued item
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);
       if (response->isSucces()) {

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -29,13 +29,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 using namespace esp32ModbusRTUInternals;  // NOLINT
 
 esp32ModbusRTU::esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin) :
+  TimeOutValue(TIMEOUT_MS),
   _serial(serial),
   _lastMillis(0),
   _interval(0),
   _rtsPin(rtsPin),
   _task(nullptr),
-  _queue(nullptr),
-  TimeOutValue(TIMEOUT_MS)  {
+  _queue(nullptr)  {
     _queue = xQueueCreate(QUEUE_SIZE, sizeof(ModbusRequest*));
 }
 

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -59,6 +59,7 @@ class esp32ModbusRTU {
   bool writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data);
   void onData(esp32Modbus::MBRTUOnData handler);
   void onError(esp32Modbus::MBRTUOnError handler);
+  void setTimeOutValue(uint32_t tov);
 
  private:
   bool _addToQueue(esp32ModbusRTUInternals::ModbusRequest* request);
@@ -67,6 +68,7 @@ class esp32ModbusRTU {
   esp32ModbusRTUInternals::ModbusResponse* _receive(esp32ModbusRTUInternals::ModbusRequest* request);
 
  private:
+  static uint32_t TimeOutValue;
   HardwareSerial* _serial;
   uint32_t _lastMillis;
   uint32_t _interval;

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -68,7 +68,7 @@ class esp32ModbusRTU {
   esp32ModbusRTUInternals::ModbusResponse* _receive(esp32ModbusRTUInternals::ModbusRequest* request);
 
  private:
-  static uint32_t TimeOutValue;
+  uint32_t TimeOutValue;
   HardwareSerial* _serial;
   uint32_t _lastMillis;
   uint32_t _interval;


### PR DESCRIPTION
Some MODBUS slaves are really slow answering. For those it is handy to be able to config the timeout value at runtime.