### PR TITLE
Remove address parameter

### DIFF
--- a/examples/SDM630/SDM630.ino
+++ b/examples/SDM630/SDM630.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(115200);  // Serial output
   Serial1.begin(9600, SERIAL_8N1, 17, 4, true);  // Modbus connection
 
-  modbus.onData([](uint8_t serverAddress, esp32Modbus::FunctionCode fc, uint16_t address, uint8_t* data, size_t length) {
+  modbus.onData([](uint8_t serverAddress, uint8_t fc, uint16_t address, uint8_t* data, size_t length) {
     Serial.printf("id 0x%02x fc 0x%02x len %u: 0x", serverAddress, fc, length);
     for (size_t i = 0; i < length; ++i) {
       Serial.printf("%02x", data[i]);

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -136,12 +136,7 @@ ModbusRequest::ModbusRequest(uint8_t length) :
   ModbusMessage(length),
   _slaveAddress(0),
   _functionCode(0),
-  _address(0),
   _byteCount(0) {}
-
-uint16_t ModbusRequest::getAddress() {
-  return _address;
-}
 
 uint8_t ModbusRequest::getSlaveAddress() {
   return _slaveAddress;
@@ -155,13 +150,12 @@ ModbusRequest02::ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_
   ModbusRequest(8) {
   _slaveAddress = slaveAddress;
   _functionCode = esp32Modbus::READ_DISCR_INPUT;
-  _address = address;
   _byteCount = numberCoils / 8 + 1;
   _token = token;
   add(_slaveAddress);
   add(_functionCode);
-  add(high(_address));
-  add(low(_address));
+  add(high(address));
+  add(low(address));
   add(high(numberCoils));
   add(low(numberCoils));
   uint16_t CRC = CRC16(_buffer, 6);
@@ -173,13 +167,12 @@ ModbusRequest03::ModbusRequest03(uint8_t slaveAddress, uint16_t address, uint16_
   ModbusRequest(12) {
   _slaveAddress = slaveAddress;
   _functionCode = esp32Modbus::READ_HOLD_REGISTER;
-  _address = address;
   _byteCount = numberRegisters * 2;  // register is 2 bytes wide
   _token = token;
   add(_slaveAddress);
   add(_functionCode);
-  add(high(_address));
-  add(low(_address));
+  add(high(address));
+  add(low(address));
   add(high(numberRegisters));
   add(low(numberRegisters));
   uint16_t CRC = CRC16(_buffer, 6);
@@ -191,13 +184,12 @@ ModbusRequest04::ModbusRequest04(uint8_t slaveAddress, uint16_t address, uint16_
   ModbusRequest(8) {
   _slaveAddress = slaveAddress;
   _functionCode = esp32Modbus::READ_INPUT_REGISTER;
-  _address = address;
   _byteCount = numberRegisters * 2;  // register is 2 bytes wide
   _token = token;
   add(_slaveAddress);
   add(_functionCode);
-  add(high(_address));
-  add(low(_address));
+  add(high(address));
+  add(low(address));
   add(high(numberRegisters));
   add(low(numberRegisters));
   uint16_t CRC = CRC16(_buffer, 6);
@@ -209,13 +201,12 @@ ModbusRequest06::ModbusRequest06(uint8_t slaveAddress, uint16_t address, uint16_
   ModbusRequest(8) {
   _slaveAddress = slaveAddress;
   _functionCode = esp32Modbus::WRITE_HOLD_REGISTER;
-  _address = address;
   _byteCount = 2;  // 1 register is 2 bytes wide
   _token = token;
   add(_slaveAddress);
   add(_functionCode);
-  add(high(_address));
-  add(low(_address));
+  add(high(address));
+  add(low(address));
   add(high(data));
   add(low(data));
   uint16_t CRC = CRC16(_buffer, 6);
@@ -227,13 +218,12 @@ ModbusRequest16::ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_
   ModbusRequest(9 + (numberRegisters * 2)) {
   _slaveAddress = slaveAddress;
   _functionCode = esp32Modbus::WRITE_MULT_REGISTERS;
-  _address = address;
   _byteCount = numberRegisters * 2;  // register is 2 bytes wide
   _token = token;
   add(_slaveAddress);
   add(_functionCode);
-  add(high(_address));
-  add(low(_address));
+  add(high(address));
+  add(low(address));
   add(high(numberRegisters));
   add(low(numberRegisters));
   add(_byteCount);
@@ -249,7 +239,6 @@ ModbusRequestRaw::ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, u
   ModbusRequest(dataLength + 4) {
   _slaveAddress = slaveAddress;
   _functionCode = functionCode;
-  _address = 0;
   _byteCount = dataLength + 2;
   _token = token;
   add(_slaveAddress);

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -139,8 +139,16 @@ ModbusRequest::ModbusRequest(uint8_t length) :
   _address(0),
   _byteCount(0) {}
 
-  uint16_t ModbusRequest::getAddress() {
+uint16_t ModbusRequest::getAddress() {
   return _address;
+}
+
+uint8_t ModbusRequest::getSlaveAddress() {
+  return _slaveAddress;
+}
+
+uint8_t ModbusRequest::getFunctionCode() {
+  return _functionCode;
 }
 
 ModbusRequest02::ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils, uint32_t token) :
@@ -263,30 +271,18 @@ ModbusResponse::ModbusResponse(uint8_t length, ModbusRequest* request) :
   _request(request),
   _error(esp32Modbus::SUCCES) { _token = request->getToken(); }
 
-bool ModbusResponse::isComplete() {
-  if (_buffer[1] > 0x80 && _index == 5) {  // 5: slaveAddress(1), errorCode(1), CRC(2) + indexed
-    return true;
-  }
-  if (_index == _request->responseLength()) return true;
-  return false;
-}
-
 bool ModbusResponse::isSucces() {
-  if (!isComplete()) {
-    _error = esp32Modbus::TIMEOUT;
-  } else if (_buffer[1] > 0x80) {
+  _error = esp32Modbus::SUCCES;
+  if (_buffer[1] > 0x80) {
     _error = static_cast<esp32Modbus::Error>(_buffer[2]);
   } else if (!checkCRC()) {
     _error = esp32Modbus::CRC_ERROR;
   // TODO(bertmelis): add other checks
-  } else {
-    _error = esp32Modbus::SUCCES;
   }
   if (_error == esp32Modbus::SUCCES) {
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 bool ModbusResponse::checkCRC() {

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -266,6 +266,36 @@ size_t ModbusRequest16::responseLength() {
   return 8;
 }
 
+ModbusRequestRaw::ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token) :
+  ModbusRequest(dataLength + 4) {
+  _slaveAddress = slaveAddress;
+  _functionCode = functionCode;
+  _address = 0;
+  _byteCount = dataLength + 2;
+  _token = token;
+  add(_slaveAddress);
+  add(_functionCode);
+  for (int i = 0; i < dataLength; i++) {
+      add(data[i]);
+    }
+  uint16_t CRC = CRC16(_buffer, _byteCount);
+  add(low(CRC));
+  add(high(CRC));
+  /*
+  Serial.print("rawRequest: ");
+  for(uint8_t i=0; i<_byteCount; ++i)
+  {
+    Serial.print(_buffer[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.println("");
+  */
+}
+
+size_t ModbusRequestRaw::responseLength() {
+  return 6;
+}
+
 ModbusResponse::ModbusResponse(uint8_t length, ModbusRequest* request) :
   ModbusMessage(length),
   _request(request),

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -330,6 +330,7 @@ void ModbusResponse::setErrorResponse(uint8_t errorCode) {
     _length = 5;
   }
   _index = 0;
+  _error = static_cast<esp32Modbus::Error>(errorCode);
   add(_request->getSlaveAddress());
   add(_request->getFunctionCode() | 0x80);
   add(errorCode);

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -305,26 +305,24 @@ uint8_t ModbusResponse::getFunctionCode() {
 
 uint8_t* ModbusResponse::getData() {
   uint8_t fc = _request->getFunctionCode();
-  if(fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
+  if (fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
     return &_buffer[3];
-  }
-  else {
+  } else {
     return &_buffer[2];
   }
 }
 
 uint8_t ModbusResponse::getByteCount() {
   uint8_t fc = _request->getFunctionCode();
-  if(fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
+  if (fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
     return _buffer[2];
-  }
-  else {
+  } else {
     return _index - 2;
   }
 }
 
 void ModbusResponse::setErrorResponse(uint8_t errorCode) {
-  if(_length != 5) {
+  if (_length != 5) {
     delete _buffer;
     _buffer = new uint8_t[5];
     _length = 5;
@@ -340,7 +338,7 @@ void ModbusResponse::setErrorResponse(uint8_t errorCode) {
 }
 
 void ModbusResponse::setData(uint16_t dataLength, uint8_t *data) {
-  if(_length != dataLength) {
+  if (_length != dataLength) {
     delete _buffer;
     _buffer = new uint8_t[dataLength];
     _length = dataLength;

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -302,14 +302,26 @@ uint8_t ModbusResponse::getSlaveAddress() {
   return _buffer[0];
 }
 
-esp32Modbus::FunctionCode ModbusResponse::getFunctionCode() {
-  return static_cast<esp32Modbus::FunctionCode>(_buffer[1]);
+uint8_t ModbusResponse::getFunctionCode() {
+  return _buffer[1];
 }
 
 uint8_t* ModbusResponse::getData() {
-  return &_buffer[3];
+  uint8_t fc = _request->getFunctionCode();
+  if(fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
+    return &_buffer[3];
+  }
+  else {
+    return &_buffer[2];
+  }
 }
 
 uint8_t ModbusResponse::getByteCount() {
-  return _buffer[2];
+  uint8_t fc = _request->getFunctionCode();
+  if(fc == 0x01 || fc == 0x02 || fc == 0x03 || fc == 0x04) {
+    return _buffer[2];
+  }
+  else {
+    return _index - 2;
+  }
 }

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -323,14 +323,14 @@ uint8_t ModbusResponse::getByteCount() {
   }
 }
 
-void ModbusResponse::setErrorResponse(uint8_t slaveAddress, uint8_t functionCode, uint8_t errorCode) {
+void ModbusResponse::setErrorResponse(uint8_t errorCode) {
   if(_length != 5) {
     delete _buffer;
     _buffer = new uint8_t[5];
   }
   _index = 0;
-  add(request->getSlaveAddress());
-  add(request->getFunctionCode() | 0x80);
+  add(_request->getSlaveAddress());
+  add(_request->getFunctionCode() | 0x80);
   add(errorCode);
   uint16_t CRC = CRC16(_buffer, 3);
   add(low(CRC));

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -327,6 +327,7 @@ void ModbusResponse::setErrorResponse(uint8_t errorCode) {
   if(_length != 5) {
     delete _buffer;
     _buffer = new uint8_t[5];
+    _length = 5;
   }
   _index = 0;
   add(_request->getSlaveAddress());
@@ -341,6 +342,7 @@ void ModbusResponse::setData(uint16_t dataLength, uint8_t *data) {
   if(_length != dataLength) {
     delete _buffer;
     _buffer = new uint8_t[dataLength];
+    _length = dataLength;
   }
   _index = dataLength;
   memcpy(_buffer, data, dataLength);

--- a/src/ModbusMessage.cpp
+++ b/src/ModbusMessage.cpp
@@ -272,11 +272,12 @@ ModbusResponse::ModbusResponse(uint8_t length, ModbusRequest* request) :
   _error(esp32Modbus::SUCCES) { _token = request->getToken(); }
 
 bool ModbusResponse::isSucces() {
-  _error = esp32Modbus::SUCCES;
   if (_buffer[1] > 0x80) {
     _error = static_cast<esp32Modbus::Error>(_buffer[2]);
   } else if (!checkCRC()) {
     _error = esp32Modbus::CRC_ERROR;
+  } else if (_buffer[0] != _request->getSlaveAddress()) {
+    _error = esp32Modbus::INVALID_SLAVE;
   // TODO(bertmelis): add other checks
   }
   if (_error == esp32Modbus::SUCCES) {

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -53,7 +53,6 @@ class ModbusResponse;  // forward declare for use in ModbusRequest
 
 class ModbusRequest : public ModbusMessage {
  public:
-  uint16_t getAddress();
   uint8_t getFunctionCode();
   uint8_t getSlaveAddress();
 
@@ -61,7 +60,6 @@ class ModbusRequest : public ModbusMessage {
   explicit ModbusRequest(uint8_t length);
   uint8_t _slaveAddress;
   uint8_t _functionCode;
-  uint16_t _address;
   uint16_t _byteCount;
 };
 

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -98,7 +98,7 @@ class ModbusRequest16 : public ModbusRequest {
 // "raw" request based on a request packet obtained as is.
 class ModbusRequestRaw : public ModbusRequest {
  public:
-  explicit ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token=0);
+  explicit ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token = 0);
 };
 
 class ModbusResponse : public ModbusMessage {

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -100,6 +100,13 @@ class ModbusRequest16 : public ModbusRequest {
   size_t responseLength();
 };
 
+// "raw" request based on a request packet obtained as is.
+class ModbusRequestRaw : public ModbusRequest {
+ public:
+  explicit ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token=0);
+  size_t responseLength();
+};
+
 class ModbusResponse : public ModbusMessage {
  public:
   explicit ModbusResponse(uint8_t length, ModbusRequest* request);

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -108,7 +108,7 @@ class ModbusResponse : public ModbusMessage {
   esp32Modbus::Error getError() const;
 
   uint8_t getSlaveAddress();
-  esp32Modbus::FunctionCode getFunctionCode();
+  uint8_t getFunctionCode();
   uint8_t* getData();
   uint8_t getByteCount();
 

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -37,6 +37,7 @@ class ModbusMessage {
   virtual ~ModbusMessage();
   uint8_t* getMessage();
   uint8_t getSize();
+  uint32_t getToken();
   void add(uint8_t value);
 
  protected:
@@ -44,6 +45,7 @@ class ModbusMessage {
   uint8_t* _buffer;
   uint8_t _length;
   uint8_t _index;
+  uint32_t _token;
 };
 
 class ModbusResponse;  // forward declare for use in ModbusRequest
@@ -64,35 +66,35 @@ class ModbusRequest : public ModbusMessage {
 // read discrete coils
 class ModbusRequest02 : public ModbusRequest {
  public:
-  explicit ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils);
+  explicit ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils, uint32_t token = 0);
   size_t responseLength();
 };
 
 // read holding registers
 class ModbusRequest03 : public ModbusRequest {
  public:
-  explicit ModbusRequest03(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
+  explicit ModbusRequest03(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
   size_t responseLength();
 };
 
 // read input registers
 class ModbusRequest04 : public ModbusRequest {
  public:
-  explicit ModbusRequest04(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
+  explicit ModbusRequest04(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
   size_t responseLength();
 };
 
 // write single holding registers
 class ModbusRequest06 : public ModbusRequest {
  public:
-  explicit ModbusRequest06(uint8_t slaveAddress, uint16_t address, uint16_t data);
+  explicit ModbusRequest06(uint8_t slaveAddress, uint16_t address, uint16_t data, uint32_t token = 0);
   size_t responseLength();
 };
 
 // write multiple holding registers
 class ModbusRequest16 : public ModbusRequest {
  public:
-  explicit ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data);
+  explicit ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data, uint32_t token = 0);
   size_t responseLength();
 };
 

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -27,6 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <stdint.h>  // for uint*_t
 #include <stddef.h>  // for size_t
+#include <cstring>  // for memcpy
 
 #include "esp32ModbusTypeDefs.h"
 
@@ -111,7 +112,7 @@ class ModbusResponse : public ModbusMessage {
   uint8_t getFunctionCode();
   uint8_t* getData();
   uint8_t getByteCount();
-  void setErrorResponse(uint8_t slaveAddress, uint8_t functionCode, uint8_t errorCode);
+  void setErrorResponse(uint8_t errorCode);
   void setData(uint16_t dataLength, uint8_t *data);
 
  private:

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -54,6 +54,8 @@ class ModbusRequest : public ModbusMessage {
  public:
   virtual size_t responseLength() = 0;
   uint16_t getAddress();
+  uint8_t getFunctionCode();
+  uint8_t getSlaveAddress();
 
  protected:
   explicit ModbusRequest(uint8_t length);
@@ -101,7 +103,6 @@ class ModbusRequest16 : public ModbusRequest {
 class ModbusResponse : public ModbusMessage {
  public:
   explicit ModbusResponse(uint8_t length, ModbusRequest* request);
-  bool isComplete();
   bool isSucces();
   bool checkCRC();
   esp32Modbus::Error getError() const;

--- a/src/ModbusMessage.h
+++ b/src/ModbusMessage.h
@@ -52,7 +52,6 @@ class ModbusResponse;  // forward declare for use in ModbusRequest
 
 class ModbusRequest : public ModbusMessage {
  public:
-  virtual size_t responseLength() = 0;
   uint16_t getAddress();
   uint8_t getFunctionCode();
   uint8_t getSlaveAddress();
@@ -69,42 +68,36 @@ class ModbusRequest : public ModbusMessage {
 class ModbusRequest02 : public ModbusRequest {
  public:
   explicit ModbusRequest02(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils, uint32_t token = 0);
-  size_t responseLength();
 };
 
 // read holding registers
 class ModbusRequest03 : public ModbusRequest {
  public:
   explicit ModbusRequest03(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
-  size_t responseLength();
 };
 
 // read input registers
 class ModbusRequest04 : public ModbusRequest {
  public:
   explicit ModbusRequest04(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
-  size_t responseLength();
 };
 
 // write single holding registers
 class ModbusRequest06 : public ModbusRequest {
  public:
   explicit ModbusRequest06(uint8_t slaveAddress, uint16_t address, uint16_t data, uint32_t token = 0);
-  size_t responseLength();
 };
 
 // write multiple holding registers
 class ModbusRequest16 : public ModbusRequest {
  public:
   explicit ModbusRequest16(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data, uint32_t token = 0);
-  size_t responseLength();
 };
 
 // "raw" request based on a request packet obtained as is.
 class ModbusRequestRaw : public ModbusRequest {
  public:
   explicit ModbusRequestRaw(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token=0);
-  size_t responseLength();
 };
 
 class ModbusResponse : public ModbusMessage {
@@ -118,6 +111,8 @@ class ModbusResponse : public ModbusMessage {
   uint8_t getFunctionCode();
   uint8_t* getData();
   uint8_t getByteCount();
+  void setErrorResponse(uint8_t slaveAddress, uint8_t functionCode, uint8_t errorCode);
+  void setData(uint16_t dataLength, uint8_t *data);
 
  private:
   ModbusRequest* _request;

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -230,10 +230,8 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
           uint8_t *temp = new uint8_t[bufferBlocks * BUFBLOCKSIZE];
           memcpy(temp, buffer, (bufferBlocks - 1) * BUFBLOCKSIZE);
           // Use intermediate pointer temp2 to keep cppcheck happy
-          uint8_t temp2 = temp;
-          temp = buffer;
-          buffer = temp2;
-          delete temp;
+          delete[] buffer;
+          buffer = temp;
         }
         // Rewind timer
         _lastMicros = micros();
@@ -281,7 +279,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   }
 
   // Deallocate buffer
-  delete buffer;
+  delete[] buffer;
   _lastMicros = micros();
 
   return response;

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -56,7 +56,7 @@ void esp32ModbusRTU::begin(int coreID /* = -1 */) {
   xTaskCreatePinnedToCore((TaskFunction_t)&_handleConnection, "esp32ModbusRTU", 4096, this, 5, &_task, coreID >= 0 ? coreID : NULL);
   // silent interval is at least 3.5x character time
   // _interval = 35000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
-  _interval = 40000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
+  _interval = 40000000UL / _serial->baudRate();  // 4 * 10 bits * 1000 µs * 1000 ms / baud
 
   // The following is okay for sending at any baud rate, but problematic at receiving with baud rates above 35000,
   // since the calculated interval will be below 1000µs!

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -248,8 +248,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       // Allocate response object
       response = new ModbusResponse(bufferPtr, request);
       // Move gathered data into it
-      memcpy(response->_buffer, buffer, bufferPtr);
-      response->_index = bufferPtr;
+      for(uint16_t fPtr = 0; fPtr < bufferPtr; fPtr++) response->add(buffer[fPtr]);
       state = FINISHED;
       break;
     // ERROR_EXIT: We had a timeout. Prepare error return object

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -248,8 +248,8 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       // Allocate response object
       response = new ModbusResponse(bufferPtr, request);
       // Move gathered data into it
-      memcpy(_buffer, buffer, bufferPtr);
-      _index = bufferPtr;
+      memcpy(response->_buffer, buffer, bufferPtr);
+      response->_index = bufferPtr;
       state = FINISHED;
       break;
     // ERROR_EXIT: We had a timeout. Prepare error return object

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -87,6 +87,11 @@ bool esp32ModbusRTU::writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t ad
   return _addToQueue(request);
 }
 
+bool esp32ModbusRTU::rawRequest(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t* data, uint32_t token) {
+  ModbusRequest* request = new ModbusRequestRaw(slaveAddress, functionCode, dataLength, data, token);
+  return _addToQueue(request);
+}
+
 void esp32ModbusRTU::onData(esp32Modbus::MBRTUOnData handler) {
   _onData = handler;
 }

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -212,7 +212,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       if (_serial->available()) {
         state = IN_PACKET;
         _lastMicros = micros();
-      } else if(millis() - TimeOut >= TimeOutValue) {
+      } else if (millis() - TimeOut >= TimeOutValue) {
         errorCode = esp32Modbus::TIMEOUT;
         state = ERROR_EXIT;
       }

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -55,7 +55,8 @@ void esp32ModbusRTU::begin(int coreID /* = -1 */) {
   }
   xTaskCreatePinnedToCore((TaskFunction_t)&_handleConnection, "esp32ModbusRTU", 4096, this, 5, &_task, coreID >= 0 ? coreID : NULL);
   // silent interval is at least 3.5x character time
-  _interval = 35000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
+  // _interval = 35000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
+  _interval = 40000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
 
   // The following is okay for sending at any baud rate, but problematic at receiving with baud rates above 35000,
   // since the calculated interval will be below 1000µs!

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -229,8 +229,11 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
           bufferBlocks++;
           uint8_t *temp = new uint8_t[bufferBlocks * BUFBLOCKSIZE];
           memcpy(temp, buffer, (bufferBlocks - 1) * BUFBLOCKSIZE);
-          delete buffer;
-          buffer = temp;
+          // Use intermediate pointer temp2 to keep cppcheck happy
+          uint8_t temp2 = temp;
+          temp = buffer;
+          buffer = temp2;
+          delete temp;
         }
         // Rewind timer
         _lastMicros = micros();

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -240,7 +240,11 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
         buffer = temp;
       }
       // Gap of at least _interval micro seconds passed without data?
-      if(micros() - _lastMicros >= _interval) {
+      // if(micros() - _lastMicros >= _interval) {
+      // The above line is the theory - in practice the FIFO copy process into
+      // the Serial buffer takes much longer than that. In lieu of a better
+      // solution we will use 16ms(!) instead of _interval :(
+      if(micros() - _lastMicros >= 16000) {
         state = DATA_READ;
       }
       break;

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -248,18 +248,13 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       // Allocate response object
       response = new ModbusResponse(bufferPtr, request);
       // Move gathered data into it
-      for(uint16_t fPtr = 0; fPtr < bufferPtr; fPtr++) response->add(buffer[fPtr]);
+      response->setData(bufferPtr, buffer);
       state = FINISHED;
       break;
     // ERROR_EXIT: We had a timeout. Prepare error return object
     case ERROR_EXIT:
       response = new ModbusResponse(5, request);
-      response->add(request->getSlaveAddress());
-      response->add(request->getFunctionCode() | 0x80);
-      response->add(errorCode);
-      uint16_t CRC = CRC16(_buffer, 3);
-      response->add(low(CRC));
-      response->add(high(CRC));
+      response->setErrorResponse(request->getSlaveAddress(), request->getFunctionCode(), errorCode);
       state = FINISHED;
       break;
     // FINISHED: we are done, keep the compiler happy by pseudo-treating it.

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -254,7 +254,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
     // ERROR_EXIT: We had a timeout. Prepare error return object
     case ERROR_EXIT:
       response = new ModbusResponse(5, request);
-      response->setErrorResponse(request->getSlaveAddress(), request->getFunctionCode(), errorCode);
+      response->setErrorResponse(errorCode);
       state = FINISHED;
       break;
     // FINISHED: we are done, keep the compiler happy by pseudo-treating it.

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -182,7 +182,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   register uint16_t bufferPtr = 0;
 
   // State machine states
-  enum STATES : uint8_t { WAIT_INTERVAL=0, WAIT_DATA, IN_PACKET, DATA_READ, ERROR_EXIT, FINISHED };
+  enum STATES : uint8_t { WAIT_INTERVAL = 0, WAIT_DATA, IN_PACKET, DATA_READ, ERROR_EXIT, FINISHED };
   register STATES state = WAIT_INTERVAL;
 
   // Timeout tracker
@@ -194,29 +194,25 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   // Return data object
   ModbusResponse* response = nullptr;
 
-  while(state != FINISHED)
-  {
-    switch(state)
-    {
+  while (state != FINISHED) {
+    switch (state) {
     // WAIT_INTERVAL: spend the remainder of the bus quiet time waiting
     case WAIT_INTERVAL:
       // Time passed?
-      if(micros() - _lastMicros >= _interval) {
+      if (micros() - _lastMicros >= _interval) {
         // Yes, proceed to reading data
         state = WAIT_DATA;
-      }
-      else {
+      } else {
         // No, wait a little longer
         delayMicroseconds(1);
       }
       break;
     // WAIT_DATA: await first data byte, but watch timeout
     case WAIT_DATA:
-      if(_serial->available()) {
+      if (_serial->available()) {
         state = IN_PACKET;
         _lastMicros = micros();
-      }
-      else if(millis() - TimeOut >= TimeOutValue) {
+      } else if(millis() - TimeOut >= TimeOutValue) {
         errorCode = esp32Modbus::TIMEOUT;
         state = ERROR_EXIT;
       }
@@ -228,7 +224,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
         // Yes. Catch the byte
         buffer[bufferPtr++] = _serial->read();
         // Buffer full?
-        if(bufferPtr >= bufferBlocks * BUFBLOCKSIZE) {
+        if (bufferPtr >= bufferBlocks * BUFBLOCKSIZE) {
           // Yes. Extend it by another block
           bufferBlocks++;
           uint8_t *temp = new uint8_t[bufferBlocks * BUFBLOCKSIZE];
@@ -247,16 +243,16 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       // the core FIFO handling takes much longer than that.
       //
       // Workaround: uncomment the following line to wait for 16ms(!) for the handling to finish:
-      if(micros() - _lastMicros >= 16000) {
+      if (micros() - _lastMicros >= 16000) {
       //
       // Alternate solution: is to modify the uartEnableInterrupt() function in
       // the core implementation file 'esp32-hal-uart.c', to have the line
       //    'uart->dev->conf1.rxfifo_full_thrhd = 1; // 112;'
-      // This will change the number of bytes received to trigger the copy interrupt 
+      // This will change the number of bytes received to trigger the copy interrupt
       // from 112 (as is implemented in the core) to 1, effectively firing the interrupt
       // for any single byte.
       // Then you may uncomment the line below instead:
-      // if(micros() - _lastMicros >= _interval) {
+      // if (micros() - _lastMicros >= _interval) {
       //
         state = DATA_READ;
       }

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -132,7 +132,6 @@ void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
           instance->_onData(
             response->getSlaveAddress(),
             response->getFunctionCode(),
-            request->getAddress(),
             response->getData(),
             response->getByteCount());
         // else, if the token onData handler is set, call that
@@ -140,7 +139,6 @@ void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
           instance->_onDataToken(
             response->getSlaveAddress(),
             response->getFunctionCode(),
-            request->getAddress(),
             response->getData(),
             response->getByteCount(),
             response->getToken());

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -181,7 +181,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   register uint16_t bufferPtr = 0;
 
   // State machine states
-  typedef enum STATES : uint8_t { WAIT_INTERVAL=0, WAIT_DATA, IN_PACKET, DATA_READ, ERROR_EXIT, FINISHED };
+  enum STATES : uint8_t { WAIT_INTERVAL=0, WAIT_DATA, IN_PACKET, DATA_READ, ERROR_EXIT, FINISHED };
   register STATES state = WAIT_INTERVAL;
 
   // Timeout tracker
@@ -211,7 +211,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       break;
     // WAIT_DATA: await first data byte, but watch timeout
     case WAIT_DATA:
-      if(_serial.available()) {
+      if(_serial->available()) {
         state = IN_PACKET;
         _lastMicros = micros();
       }
@@ -225,7 +225,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       // Data waiting and space left in buffer?
       while (bufferPtr < bufferBlocks * BUFBLOCKSIZE && _serial->available()) {
         // Yes. Catch the byte
-        buffer[bufferPtr++] = _serial.read();
+        buffer[bufferPtr++] = _serial->read();
         // Rewind timer
         _lastMicros = micros();
       }
@@ -262,6 +262,9 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
       response->add(low(CRC));
       response->add(high(CRC));
       state = FINISHED;
+      break;
+    // FINISHED: we are done, keep the compiler happy by pseudo-treating it.
+    case FINISHED:
       break;
     }
   }

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -31,11 +31,15 @@ using namespace esp32ModbusRTUInternals;  // NOLINT
 esp32ModbusRTU::esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin) :
   TimeOutValue(TIMEOUT_MS),
   _serial(serial),
-  _lastMillis(0),
+  _lastMicros(0),
   _interval(0),
   _rtsPin(rtsPin),
   _task(nullptr),
-  _queue(nullptr)  {
+  _queue(nullptr),
+  _onData(nullptr),
+  _onError(nullptr),
+  _onDataToken(nullptr),
+  _onErrorToken(nullptr)  {
     _queue = xQueueCreate(QUEUE_SIZE, sizeof(ModbusRequest*));
 }
 
@@ -51,31 +55,35 @@ void esp32ModbusRTU::begin(int coreID /* = -1 */) {
   }
   xTaskCreatePinnedToCore((TaskFunction_t)&_handleConnection, "esp32ModbusRTU", 4096, this, 5, &_task, coreID >= 0 ? coreID : NULL);
   // silent interval is at least 3.5x character time
-  _interval = 40000 / _serial->baudRate();  // 4 * 1000 * 10 / baud
-  if (_interval == 0) _interval = 1;  // minimum of 1msec interval
+  _interval = 35000000UL / _serial->baudRate();  // 3.5 * 10 bits * 1000 µs * 1000 ms / baud
+
+  // The following is okay for sending at any baud rate, but problematic at receiving with baud rates above 35000,
+  // since the calculated interval will be below 1000µs!
+  // f.i. 115200bd ==> interval=304µs
+  if (_interval < 1000) _interval = 1000;  // minimum of 1msec interval
 }
 
-bool esp32ModbusRTU::readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils) {
-  ModbusRequest* request = new ModbusRequest02(slaveAddress, address, numberCoils);
+bool esp32ModbusRTU::readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils, uint32_t token) {
+  ModbusRequest* request = new ModbusRequest02(slaveAddress, address, numberCoils, token);
   return _addToQueue(request);
 }
-bool esp32ModbusRTU::readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters) {
-  ModbusRequest* request = new ModbusRequest03(slaveAddress, address, numberRegisters);
-  return _addToQueue(request);
-}
-
-bool esp32ModbusRTU::readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters) {
-  ModbusRequest* request = new ModbusRequest04(slaveAddress, address, numberRegisters);
-  return _addToQueue(request);
-}
-
-bool esp32ModbusRTU::writeSingleHoldingRegister(uint8_t slaveAddress, uint16_t address, uint16_t data) {
-  ModbusRequest* request = new ModbusRequest06(slaveAddress, address, data);
+bool esp32ModbusRTU::readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token) {
+  ModbusRequest* request = new ModbusRequest03(slaveAddress, address, numberRegisters, token);
   return _addToQueue(request);
 }
 
-bool esp32ModbusRTU::writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data) {
-  ModbusRequest* request = new ModbusRequest16(slaveAddress, address, numberRegisters, data);
+bool esp32ModbusRTU::readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token) {
+  ModbusRequest* request = new ModbusRequest04(slaveAddress, address, numberRegisters, token);
+  return _addToQueue(request);
+}
+
+bool esp32ModbusRTU::writeSingleHoldingRegister(uint8_t slaveAddress, uint16_t address, uint16_t data, uint32_t token) {
+  ModbusRequest* request = new ModbusRequest06(slaveAddress, address, data, token);
+  return _addToQueue(request);
+}
+
+bool esp32ModbusRTU::writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data, uint32_t token) {
+  ModbusRequest* request = new ModbusRequest16(slaveAddress, address, numberRegisters, data, token);
   return _addToQueue(request);
 }
 
@@ -85,6 +93,14 @@ void esp32ModbusRTU::onData(esp32Modbus::MBRTUOnData handler) {
 
 void esp32ModbusRTU::onError(esp32Modbus::MBRTUOnError handler) {
   _onError = handler;
+}
+
+void esp32ModbusRTU::onDataToken(esp32Modbus::MBRTUOnDataToken handler) {
+  _onDataToken = handler;
+}
+
+void esp32ModbusRTU::onErrorToken(esp32Modbus::MBRTUOnErrorToken handler) {
+  _onErrorToken = handler;
 }
 
 bool esp32ModbusRTU::_addToQueue(ModbusRequest* request) {
@@ -105,9 +121,28 @@ void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
       instance->_send(request->getMessage(), request->getSize());
       ModbusResponse* response = instance->_receive(request);
       if (response->isSucces()) {
-        if (instance->_onData) instance->_onData(response->getSlaveAddress(), response->getFunctionCode(), request->getAddress(), response->getData(), response->getByteCount());
+        // if the non-token onData handler is set, call it
+        if (instance->_onData)
+          instance->_onData(
+            response->getSlaveAddress(),
+            response->getFunctionCode(),
+            request->getAddress(),
+            response->getData(),
+            response->getByteCount());
+        // else, if the token onData handler is set, call that
+        else if (instance->_onDataToken)
+          instance->_onDataToken(
+            response->getSlaveAddress(),
+            response->getFunctionCode(),
+            request->getAddress(),
+            response->getData(),
+            response->getByteCount(),
+            response->getToken());
       } else {
+        // Same for error responses. non-token onError set?
         if (instance->_onError) instance->_onError(response->getError());
+        // No, but token onError instead?
+        else if (instance->_onErrorToken) instance->_onErrorToken(response->getError(), response->getToken());
       }
       delete request;  // object created in public methods
       delete response;  // object created in _receive()
@@ -116,14 +151,14 @@ void esp32ModbusRTU::_handleConnection(esp32ModbusRTU* instance) {
 }
 
 void esp32ModbusRTU::_send(uint8_t* data, uint8_t length) {
-  while (millis() - _lastMillis < _interval) delay(1);  // respect _interval
+  while (micros() - _lastMicros < _interval) delayMicroseconds(1);  // respect _interval
   // Toggle rtsPin, if necessary
   if (_rtsPin >= 0) digitalWrite(_rtsPin, HIGH);
   _serial->write(data, length);
   _serial->flush();
   // Toggle rtsPin, if necessary
   if (_rtsPin >= 0) digitalWrite(_rtsPin, LOW);
-  _lastMillis = millis();
+  _lastMicros = micros();
 }
 
 // Adjust timeout on MODBUS - some slaves require longer/allow for shorter times
@@ -133,15 +168,16 @@ void esp32ModbusRTU::setTimeOutValue(uint32_t tov) {
 
 ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
   ModbusResponse* response = new ModbusResponse(request->responseLength(), request);
+  uint32_t lastMillis = millis();
   while (true) {
     while (_serial->available()) {
       response->add(_serial->read());
     }
     if (response->isComplete()) {
-      _lastMillis = millis();
+      lastMillis = millis();
       break;
     }
-    if (millis() - _lastMillis > TimeOutValue) {
+    if (millis() - lastMillis > TimeOutValue) {
       break;
     }
     delay(1);  // take care of watchdog

--- a/src/esp32ModbusRTU.cpp
+++ b/src/esp32ModbusRTU.cpp
@@ -240,7 +240,7 @@ ModbusResponse* esp32ModbusRTU::_receive(ModbusRequest* request) {
         buffer = temp;
       }
       // Gap of at least _interval micro seconds passed without data?
-      if(micros() - _lastMicros <= _interval) {
+      if(micros() - _lastMicros >= _interval) {
         state = DATA_READ;
       }
       break;

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -57,6 +57,7 @@ class esp32ModbusRTU {
   bool readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
   bool writeSingleHoldingRegister(uint8_t slaveAddress, uint16_t address, uint16_t data, uint32_t token = 0);
   bool writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data, uint32_t token = 0);
+  bool rawRequest(uint8_t slaveAddress, uint8_t functionCode, uint16_t dataLength, uint8_t *data, uint32_t token = 0);
   void onData(esp32Modbus::MBRTUOnData handler);
   void onError(esp32Modbus::MBRTUOnError handler);
   void onDataToken(esp32Modbus::MBRTUOnDataToken handler);

--- a/src/esp32ModbusRTU.h
+++ b/src/esp32ModbusRTU.h
@@ -52,13 +52,15 @@ class esp32ModbusRTU {
   explicit esp32ModbusRTU(HardwareSerial* serial, int8_t rtsPin = -1);
   ~esp32ModbusRTU();
   void begin(int coreID = -1);
-  bool readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils);
-  bool readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
-  bool readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters);
-  bool writeSingleHoldingRegister(uint8_t slaveAddress, uint16_t address, uint16_t data);
-  bool writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data);
+  bool readDiscreteInputs(uint8_t slaveAddress, uint16_t address, uint16_t numberCoils, uint32_t token = 0);
+  bool readHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
+  bool readInputRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint32_t token = 0);
+  bool writeSingleHoldingRegister(uint8_t slaveAddress, uint16_t address, uint16_t data, uint32_t token = 0);
+  bool writeMultHoldingRegisters(uint8_t slaveAddress, uint16_t address, uint16_t numberRegisters, uint8_t* data, uint32_t token = 0);
   void onData(esp32Modbus::MBRTUOnData handler);
   void onError(esp32Modbus::MBRTUOnError handler);
+  void onDataToken(esp32Modbus::MBRTUOnDataToken handler);
+  void onErrorToken(esp32Modbus::MBRTUOnErrorToken handler);
   void setTimeOutValue(uint32_t tov);
 
  private:
@@ -70,13 +72,15 @@ class esp32ModbusRTU {
  private:
   uint32_t TimeOutValue;
   HardwareSerial* _serial;
-  uint32_t _lastMillis;
+  uint32_t _lastMicros;
   uint32_t _interval;
   int8_t _rtsPin;
   TaskHandle_t _task;
   QueueHandle_t _queue;
   esp32Modbus::MBRTUOnData _onData;
   esp32Modbus::MBRTUOnError _onError;
+  esp32Modbus::MBRTUOnDataToken _onDataToken;
+  esp32Modbus::MBRTUOnErrorToken _onErrorToken;
 };
 
 #endif

--- a/src/esp32ModbusTypeDefs.h
+++ b/src/esp32ModbusTypeDefs.h
@@ -60,12 +60,12 @@ enum Error : uint8_t {
   COMM_ERROR            = 0xE4  // general communication error
 };
 
-typedef std::function<void(uint16_t, uint8_t, esp32Modbus::FunctionCode, uint8_t*, uint16_t)> MBTCPOnData;
-typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint16_t, uint8_t*, uint16_t)> MBRTUOnData;
+typedef std::function<void(uint16_t, uint8_t, uint8_t, uint8_t*, uint16_t)> MBTCPOnData;
+typedef std::function<void(uint8_t, uint8_t, uint16_t, uint8_t*, uint16_t)> MBRTUOnData;
 typedef std::function<void(uint16_t, esp32Modbus::Error)> MBTCPOnError;
 typedef std::function<void(esp32Modbus::Error)> MBRTUOnError;
-typedef std::function<void(uint16_t, uint8_t, esp32Modbus::FunctionCode, uint8_t*, uint16_t, uint32_t)> MBTCPOnDataToken;
-typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint16_t, uint8_t*, uint16_t, uint32_t)> MBRTUOnDataToken;
+typedef std::function<void(uint16_t, uint8_t, uint8_t, uint8_t*, uint16_t, uint32_t)> MBTCPOnDataToken;
+typedef std::function<void(uint8_t, uint8_t, uint16_t, uint8_t*, uint16_t, uint32_t)> MBRTUOnDataToken;
 typedef std::function<void(uint16_t, esp32Modbus::Error, uint32_t)> MBTCPOnErrorToken;
 typedef std::function<void(esp32Modbus::Error, uint32_t)> MBRTUOnErrorToken;
 

--- a/src/esp32ModbusTypeDefs.h
+++ b/src/esp32ModbusTypeDefs.h
@@ -60,13 +60,9 @@ enum Error : uint8_t {
   COMM_ERROR            = 0xE4  // general communication error
 };
 
-typedef std::function<void(uint16_t, uint8_t, uint8_t, uint8_t*, uint16_t)> MBTCPOnData;
-typedef std::function<void(uint8_t, uint8_t, uint16_t, uint8_t*, uint16_t)> MBRTUOnData;
-typedef std::function<void(uint16_t, esp32Modbus::Error)> MBTCPOnError;
+typedef std::function<void(uint8_t, uint8_t, uint8_t*, uint16_t)> MBRTUOnData;
 typedef std::function<void(esp32Modbus::Error)> MBRTUOnError;
-typedef std::function<void(uint16_t, uint8_t, uint8_t, uint8_t*, uint16_t, uint32_t)> MBTCPOnDataToken;
-typedef std::function<void(uint8_t, uint8_t, uint16_t, uint8_t*, uint16_t, uint32_t)> MBRTUOnDataToken;
-typedef std::function<void(uint16_t, esp32Modbus::Error, uint32_t)> MBTCPOnErrorToken;
+typedef std::function<void(uint8_t, uint8_t, uint8_t*, uint16_t, uint32_t)> MBRTUOnDataToken;
 typedef std::function<void(esp32Modbus::Error, uint32_t)> MBRTUOnErrorToken;
 
 }  // namespace esp32Modbus

--- a/src/esp32ModbusTypeDefs.h
+++ b/src/esp32ModbusTypeDefs.h
@@ -64,6 +64,10 @@ typedef std::function<void(uint16_t, uint8_t, esp32Modbus::FunctionCode, uint8_t
 typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint16_t, uint8_t*, uint16_t)> MBRTUOnData;
 typedef std::function<void(uint16_t, esp32Modbus::Error)> MBTCPOnError;
 typedef std::function<void(esp32Modbus::Error)> MBRTUOnError;
+typedef std::function<void(uint16_t, uint8_t, esp32Modbus::FunctionCode, uint8_t*, uint16_t, uint32_t)> MBTCPOnDataToken;
+typedef std::function<void(uint8_t, esp32Modbus::FunctionCode, uint16_t, uint8_t*, uint16_t, uint32_t)> MBRTUOnDataToken;
+typedef std::function<void(uint16_t, esp32Modbus::Error, uint32_t)> MBTCPOnErrorToken;
+typedef std::function<void(esp32Modbus::Error, uint32_t)> MBRTUOnErrorToken;
 
 }  // namespace esp32Modbus
 

--- a/tests/Test_ModbusMessage.cpp
+++ b/tests/Test_ModbusMessage.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Read input registers", "[FC04]") {
   REQUIRE(request->getSize() == sizeof(stdMessage));
   REQUIRE_THAT(request->getMessage(), ByteArrayEqual(stdMessage, sizeof(stdMessage)));
 
-  esp32ModbusRTUInternals::ModbusResponse* response = new esp32ModbusRTUInternals::ModbusResponse(request->responseLength(), request);
+  esp32ModbusRTUInternals::ModbusResponse* response = new esp32ModbusRTUInternals::ModbusResponse(7, request);
 
   SECTION("normal response") {
     for (uint8_t i = 0; i < sizeof(stdResponse); ++i) {
@@ -48,7 +48,7 @@ TEST_CASE("Write multiple holding registers", "[FC16]") {
   REQUIRE(request->getSize() == sizeof(stdMessage));
   REQUIRE_THAT(request->getMessage(), ByteArrayEqual(stdMessage, sizeof(stdMessage)));
 
-  esp32ModbusRTUInternals::ModbusResponse* response = new esp32ModbusRTUInternals::ModbusResponse(request->responseLength(), request);
+  esp32ModbusRTUInternals::ModbusResponse* response = new esp32ModbusRTUInternals::ModbusResponse(8, request);
 
   SECTION("normal response") {
     for (uint8_t i = 0; i < sizeof(stdResponse); ++i) {


### PR DESCRIPTION
Removed the address parameter in onData and onDataToken handler calls, plus the preparational statements to provide them.

The address is a partly valid reference only with function codes using it, those just executing commands without dedicated address would not benefit. The universal ``token`` parameter serves the same purpose, but regardless of function code. As it is a user-defined ``uint32_t`` value, uniqueness can be maintained by the application. 